### PR TITLE
load sam_hq to cpu if cuda is unavailable

### DIFF
--- a/py/sam_hq/build_sam_hq.py
+++ b/py/sam_hq/build_sam_hq.py
@@ -64,7 +64,10 @@ def _load_sam_checkpoint(sam: Sam, checkpoint=None):
     sam.eval()
     if checkpoint is not None:
         with open(checkpoint, "rb") as f:
-            state_dict = torch.load(f)
+            if torch.cuda.is_available():
+                state_dict = torch.load(f)
+            else:
+                state_dict = torch.load(f, map_location=torch.device('cpu'))
         info = sam.load_state_dict(state_dict, strict=False)
         print(info)
     for _, p in sam.named_parameters():


### PR DESCRIPTION
fixes RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.

necessary e.g. on apple silicon devices