### PR TITLE
fix: Resolve mask shape incompatibility issue in LAMA model with newer PyTorch versions

### DIFF
--- a/py/iopaint/model/base.py
+++ b/py/iopaint/model/base.py
@@ -75,7 +75,12 @@ class InpaintModel:
         result, image, mask = self.forward_post_process(result, image, mask, config)
 
         if config.sd_keep_unmasked_area:
-            mask = mask[:, :, np.newaxis]
+            # 确保mask是(H, W, 1)形状
+            if mask.ndim == 4:
+                mask = mask.squeeze()  # 移除所有长度为1的维度，变为(H, W)
+            if mask.ndim == 2:
+                mask = mask[..., np.newaxis]  # 添加通道维度，变为(H, W, 1)
+            
             result = result * (mask / 255) + image[:, :, ::-1] * (1 - (mask / 255))
         return result
 


### PR DESCRIPTION
After upgrading PyTorch, the mask array shape became (H, W, 1, 1), which is incompatible with the image array shape (H, W, 3) during broadcasting. This caused the error: "ValueError: operands could not be broadcast together".

The fix adds shape validation and adjustment to ensure the mask is always in (H, W, 1) format before blending operations.

Location: _pad_forward method in iopaint/model/base.pynd adjustment to ensure the mask is always in (H, W, 1) format before blending operations.