### PR TITLE
Update Gemini models and fix inline_data check

### DIFF
--- a/py/gemini.py
+++ b/py/gemini.py
@@ -392,6 +392,7 @@ class LS_Gemini_Image_Edit:
     def INPUT_TYPES(self):
         gemini_model_list = [
             "gemini-2.0-flash-exp-image-generation",
+            "gemini-2.5-flash-image-preview"
         ]
 
         return {
@@ -465,7 +466,7 @@ class LS_Gemini_Image_Edit:
             )
 
             for item in response.candidates[0].content.parts:
-                if hasattr(item, "inline_data") and item.inline_data.mime_type == "image/png":
+                if hasattr(item, "inline_data") and item.inline_data is not None and item.inline_data.mime_type == "image/png":
                     image_bytes = item.inline_data.data
                     image_bytes = io.BytesIO(image_bytes)
                     image_bytes.seek(0)


### PR DESCRIPTION
2个优化：
1）在image edit部分加入了对gemini-2.5-flash-image-preview（Nano banana）的支持；
2）修复了image edit部分如果输入图片是png格式会报`'NoneType' object has no attribute 'mime_type'` 的问题

效果如下：
<img width="2120" height="1218" alt="image" src="https://github.com/user-attachments/assets/e755ccd1-e81f-43f0-a08f-8d93f88555cc" />
