### PR TITLE
Fix Florence2 generate None past_key_values by disabling cache

### DIFF
--- a/py/florence2_ultra.py
+++ b/py/florence2_ultra.py
@@ -219,6 +219,9 @@ def run_example(model, processor, task_prompt, image, max_new_tokens, num_beams,
         early_stopping=False,
         do_sample=do_sample,
         num_beams=num_beams,
+        # Florence-2 remote code sometimes returns None past_key_values with beam search.
+        # Disabling cache avoids accessing shape on a None object.
+        use_cache=False,
     )
     generated_text = processor.batch_decode(generated_ids, skip_special_tokens=False)[0]
     parsed_answer = processor.post_process_generation(


### PR DESCRIPTION
A huge thanks to KJ—this PR fixes the Florence2 issue.Simply copy the following file to models\florence2\large-PromptGen-v2.0 to overwrite the existing one.
[modeling_florence2.py](https://github.com/user-attachments/files/24100212/modeling_florence2.py)
