### PR TITLE
Fix mask broadcasting error for MediaPipe ≥0.10.30

### DIFF
--- a/py/person_mask_Ultra.py
+++ b/py/person_mask_Ultra.py
@@ -115,7 +115,14 @@ class PersonMaskUltra:
                     mask_arrays.append(mask_background_array)
                 else:
                     for i, mask in enumerate(masks):
-                        condition = np.stack((mask.numpy_view(),) * image_shape[-1], axis=-1) > confidence
+                        mask_2d = mask.numpy_view()
+                        if mask_2d.ndim == 3 and mask_2d.shape[2] == 1:
+                            mask_2d = mask_2d.squeeze(axis=2)
+                        elif mask_2d.ndim != 2:
+                            raise ValueError(f"Unexpected mask shape: {mask_2d.shape}")
+                        condition = np.stack((mask_2d,) * image_shape[-1], axis=-1) > confidence
+                        if condition.ndim == 4 and condition.shape[2] == 1:
+                            condition = condition.squeeze(2)
                         mask_array = np.where(condition, mask_foreground_array, mask_background_array)
                         mask_arrays.append(mask_array)
                 # Merge our masks taking the maximum from each

--- a/py/person_mask_ultra_v2.py
+++ b/py/person_mask_ultra_v2.py
@@ -131,7 +131,14 @@ class PersonMaskUltraV2:
                     mask_arrays.append(mask_background_array)
                 else:
                     for i, mask in enumerate(masks):
-                        condition = np.stack((mask.numpy_view(),) * image_shape[-1], axis=-1) > confidence
+                        mask_2d = mask.numpy_view()
+                        if mask_2d.ndim == 3 and mask_2d.shape[2] == 1:
+                            mask_2d = mask_2d.squeeze(axis=2)
+                        elif mask_2d.ndim != 2:
+                            raise ValueError(f"Unexpected mask shape: {mask_2d.shape}")
+                        condition = np.stack((mask_2d,) * image_shape[-1], axis=-1) > confidence
+                        if condition.ndim == 4 and condition.shape[2] == 1:
+                            condition = condition.squeeze(2)
                         mask_array = np.where(condition, mask_foreground_array, mask_background_array)
                         mask_arrays.append(mask_array)
                 # Merge our masks taking the maximum from each


### PR DESCRIPTION
## Problem

The `PersonMaskUltra` node crashes with:

ValueError: operands could not be broadcast together with shapes (1024,768,1,4) (1024,768,4) (1024,768,4)

This occurs because `segmented_masks.confidence_masks[i].numpy_view()` can return a `(H, W, 1)` array (instead of expected `(H, W)`), depending on the MediaPipe model or version. When this is stacked into a multi-channel condition tensor, it results in shape `(H, W, 1, 4)`, which is incompatible with the `(H, W, 4)` foreground/background arrays in `np.where()`.

**Root cause**:

Starting from pypi **MediaPipe v0.10.30**, `segmented_masks.confidence_masks[i].numpy_view()` returns a **`(H, W, 1)`** array instead of the expected `(H, W)`

✅ Verified:

| MediaPipe Version | Mask Shape  | Works? |
| ----------------- | ----------- | ------ |
| `≤ 0.10.21`       | `(H, W)`    | Yes    |
| `≥ 0.10.30`       | `(H, W, 1)` | No     |
| `0.10.31`         | `(H, W, 1)` | No     |

## Fix

Before constructing the condition tensor:
- Explicitly check if the mask from MediaPipe has shape `(H, W, 1)`
- Squeeze the trailing singleton dimension to ensure it's strictly `(H, W)`
- Add a safeguard to raise an error for unexpected shapes

This ensures `np.stack(..., axis=-1)` always produces a `(H, W, 4)` condition tensor, matching the other operands.